### PR TITLE
Back compatibility

### DIFF
--- a/geniesp/bpc_config.py
+++ b/geniesp/bpc_config.py
@@ -69,7 +69,7 @@ class Panc(BpcProjectRunner):
     # Sponsorted project name
     _SPONSORED_PROJECT = 'PANC'
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.14"
     # Mapping from Synapse Table to form (derived files)
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples
@@ -87,7 +87,7 @@ class Prostate(BpcProjectRunner):
     # Sponsorted project name
     _SPONSORED_PROJECT = 'Prostate'
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.14"
     # Mapping from Synapse Table to form (derived files)
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -912,19 +912,21 @@ class BpcProjectRunner(metaclass=ABCMeta):
         treatment_data = self.make_timeline_treatmentdf(
             timeline_infodf, "TIMELINE-TREATMENT"
         )
-        print("TREATMENT-RAD")
-        # TODO: Add rt_rt_int
-        treatment_rad_data = self.create_fixed_timeline_files(
-            timeline_infodf, "TIMELINE-TREATMENT-RT"
-        )
-        rad_df = treatment_rad_data['df']
-        rad_df['STOP_DATE'] = rad_df['START_DATE'] + rad_df['TEMP']
-        rad_df = rad_df[rad_df['INDEX_CANCER'] == "Yes"]
-        del rad_df['INDEX_CANCER']
-        del rad_df['TEMP']
-        treatment_data['df'] = treatment_data['df'].append(
-            rad_df
-        )
+
+        if self._SPONSORED_PROJECT not in ['BrCa', 'CRC', 'NSCLC']:
+            print("TREATMENT-RAD")
+            # TODO: Add rt_rt_int
+            treatment_rad_data = self.create_fixed_timeline_files(
+                timeline_infodf, "TIMELINE-TREATMENT-RT"
+            )
+            rad_df = treatment_rad_data['df']
+            rad_df['STOP_DATE'] = rad_df['START_DATE'] + rad_df['TEMP']
+            rad_df = rad_df[rad_df['INDEX_CANCER'] == "Yes"]
+            del rad_df['INDEX_CANCER']
+            del rad_df['TEMP']
+            treatment_data['df'] = treatment_data['df'].append(
+                rad_df
+            )
         treatment_path = os.path.join(self._SPONSORED_PROJECT,
                                       "data_timeline_treatment.txt")
         self.write_and_storedf(treatment_data['df'], treatment_path,

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -582,7 +582,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
             else:
                 final_timelinedf[row['cbio']] = melted_df[row['cbio']]
         final_timelinedf['EVENT_TYPE'] = "Treatment"
-        final_timelinedf['TREATMENT_TYPE'] = "Systemic Therapy"
+        final_timelinedf['TREATMENT_TYPE'] = "Medical Type"
         # Remove all START_DATE is NULL
         final_timelinedf = final_timelinedf[
             ~final_timelinedf['START_DATE'].isnull()


### PR DESCRIPTION
Modifications to allow for regeneration of cBioPortal files for older BPC cohorts (i.e. NSCLC, CRC, BrCa)
1. store version of mapping table for PANC and Prostate cohorts
2. reverted key from mapping to older label
3. made construction of radiation treatment timeline conditional on cohort as NSCLC, CRC, BrCa have no radiation treatment mappings specified