### PR TITLE
account for missing AGENT

### DIFF
--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -600,12 +600,10 @@ class BpcProjectRunner(metaclass=ABCMeta):
         # Make sure all events types are treatment
         final_timelinedf["EVENT_TYPE"] = "Treatment"
 
-        # Make sure AGENT doesn't have parenthesis
+        # Make sure AGENT is not null and doesn't have parenthesis
         agents = []
+        final_timelinedf[~final_timelinedf["AGENT"].isnull()]
         for index, agent in enumerate(final_timelinedf["AGENT"]):
-            print(f"index = {index}")
-            print(f"agent = {agent}")
-            print(final_timelinedf.iloc[index])
             if "(" in agent:
                 agents.append(agent.split("(")[0].strip())
             else:

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -604,6 +604,8 @@ class BpcProjectRunner(metaclass=ABCMeta):
         agents = []
         print(final_timelinedf["AGENT"])
         for index, agent in enumerate(final_timelinedf["AGENT"]):
+            print(f"index = {index}")
+            print(f"agent = {agent}")
             if "(" in agent:
                 agents.append(agent.split("(")[0].strip())
             else:

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -602,7 +602,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
 
         # Make sure AGENT is not null and doesn't have parenthesis
         agents = []
-        final_timelinedf[~final_timelinedf["AGENT"].isnull()]
+        final_timelinedf = final_timelinedf[~final_timelinedf["AGENT"].isnull()]
         for index, agent in enumerate(final_timelinedf["AGENT"]):
             if "(" in agent:
                 agents.append(agent.split("(")[0].strip())

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -602,10 +602,10 @@ class BpcProjectRunner(metaclass=ABCMeta):
 
         # Make sure AGENT doesn't have parenthesis
         agents = []
-        print(final_timelinedf["AGENT"])
         for index, agent in enumerate(final_timelinedf["AGENT"]):
             print(f"index = {index}")
             print(f"agent = {agent}")
+            print(final_timelinedf.iloc[index])
             if "(" in agent:
                 agents.append(agent.split("(")[0].strip())
             else:

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -602,6 +602,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
 
         # Make sure AGENT doesn't have parenthesis
         agents = []
+        print(final_timelinedf["AGENT"])
         for index, agent in enumerate(final_timelinedf["AGENT"]):
             if "(" in agent:
                 agents.append(agent.split("(")[0].strip())


### PR DESCRIPTION
Fixes #59

A problem with underlying data made AGENT (drug name) nan while other associated drug data was present.  This modification removes any drugs information with AGENT nan.  Either downstream QC or a new QA check will account for this issue in the actual data submissions going forward.