### PR TITLE
update mapping table

### DIFF
--- a/geniesp/bpc_config.py
+++ b/geniesp/bpc_config.py
@@ -12,7 +12,7 @@ class Brca(BpcProjectRunner):
     # Sponsored project name
     _SPONSORED_PROJECT = "BrCa"
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.7"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.24"
     # Mapping from Synapse Table to form (derived files)
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples
@@ -34,7 +34,7 @@ class Crc(BpcProjectRunner):
     # Sponsored project name
     _SPONSORED_PROJECT = "CRC"
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.6"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.24"
     # Mapping from Synapse Table to form (derived files)
     # TODO: Make versioned
     _DATA_TABLE_IDS = "syn22296821"


### PR DESCRIPTION
Fixes #63 

Need to update mapping table version even for older cohorts because updates to derived variable files from which variables are drawn are refreshed for all cohorts simultaneously.

Also corrects un-noted issue for CRC as well.  

Confirmed code now runs for older cohorts

```
geniesp CRC 1.2-consortium --staging
geniesp BrCa 1.1-consortium --staging
```