### PR TITLE
fix inconsistencies between cBioPortal and clinical files

### DIFF
--- a/geniesp/bpc_config.py
+++ b/geniesp/bpc_config.py
@@ -12,7 +12,7 @@ class Brca(BpcProjectRunner):
     # Sponsored project name
     _SPONSORED_PROJECT = "BrCa"
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.27"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.28"
     # Mapping from Synapse Table to form (derived files)
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples
@@ -34,7 +34,7 @@ class Crc(BpcProjectRunner):
     # Sponsored project name
     _SPONSORED_PROJECT = "CRC"
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.27"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.28"
     # Mapping from Synapse Table to form (derived files)
     # TODO: Make versioned
     _DATA_TABLE_IDS = "syn22296821"
@@ -57,7 +57,7 @@ class Nsclc(BpcProjectRunner):
     # Sponsored project name
     _SPONSORED_PROJECT = "NSCLC"
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.27"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.28"
     # Mapping from Synapse Table to form (derived files)
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples
@@ -80,7 +80,7 @@ class Panc(BpcProjectRunner):
     # Sponsored project name
     _SPONSORED_PROJECT = "PANC"
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.27"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.28"
     # Mapping from Synapse Table to form (derived files)
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples
@@ -102,7 +102,7 @@ class Prostate(BpcProjectRunner):
     # Sponsored project name
     _SPONSORED_PROJECT = "Prostate"
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.27"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.28"
     # Mapping from Synapse Table to form (derived files)
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples
@@ -124,7 +124,7 @@ class Bladder(BpcProjectRunner):
     # Sponsored project name
     _SPONSORED_PROJECT = "BLADDER"
     # Redcap codes to cbioportal mapping synid and form key is in
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.27"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.28"
     # Mapping from Synapse Table to form (derived files)
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1360,7 +1360,6 @@ class BpcProjectRunner(metaclass=ABCMeta):
             "AGE_AT_SEQ_REPORT_YEARS",
             "CPT_ORDER_INT",
             "CPT_REPORT_INT",
-            "AGE_AT_SEQUENCING",
         ]
         for col in days_to_years_col:
             # not all columns could exist, so check if column exists

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1331,23 +1331,23 @@ class BpcProjectRunner(metaclass=ABCMeta):
             "supp_survival_treatment",
         )
         # Fill in ONCOTREE_CODE
-        final_sampledf["ONCOTREE_CODE"] = [
-            self.genie_clinicaldf["ONCOTREE_CODE"][
-                self.genie_clinicaldf["SAMPLE_ID"] == sample
-            ].values[0]
-            if sum(self.genie_clinicaldf["SAMPLE_ID"] == sample) > 0
-            else float("nan")
-            for sample in final_sampledf["SAMPLE_ID"]
-        ]
-        # Fill in SEQ_ASSAY_ID
-        final_sampledf["SEQ_ASSAY_ID"] = [
-            self.genie_clinicaldf["SEQ_ASSAY_ID"][
-                self.genie_clinicaldf["SAMPLE_ID"] == sample
-            ].values[0]
-            if sum(self.genie_clinicaldf["SAMPLE_ID"] == sample) > 0
-            else float("nan")
-            for sample in final_sampledf["SAMPLE_ID"]
-        ]
+        # final_sampledf["ONCOTREE_CODE"] = [
+        #     self.genie_clinicaldf["ONCOTREE_CODE"][
+        #         self.genie_clinicaldf["SAMPLE_ID"] == sample
+        #     ].values[0]
+        #     if sum(self.genie_clinicaldf["SAMPLE_ID"] == sample) > 0
+        #     else float("nan")
+        #     for sample in final_sampledf["SAMPLE_ID"]
+        # ]
+        # # Fill in SEQ_ASSAY_ID
+        # final_sampledf["SEQ_ASSAY_ID"] = [
+        #     self.genie_clinicaldf["SEQ_ASSAY_ID"][
+        #         self.genie_clinicaldf["SAMPLE_ID"] == sample
+        #     ].values[0]
+        #     if sum(self.genie_clinicaldf["SAMPLE_ID"] == sample) > 0
+        #     else float("nan")
+        #     for sample in final_sampledf["SAMPLE_ID"]
+        # ]
 
         subset_sampledf = final_sampledf[
             final_sampledf["SAMPLE_ID"].isin(self.genie_clinicaldf["SAMPLE_ID"])
@@ -1368,11 +1368,12 @@ class BpcProjectRunner(metaclass=ABCMeta):
                 subset_sampledf[col] = years
 
         # Remove SAMPLE_TYPE and CPT_SEQ_DATE because the values are incorrect
-        del subset_sampledf["SAMPLE_TYPE"]
+        #del subset_sampledf["SAMPLE_TYPE"]
         del subset_sampledf["CPT_SEQ_DATE"]
         # Obtain this information from the main GENIE cohort
         subset_sampledf = subset_sampledf.merge(
-            self.genie_clinicaldf[["SAMPLE_ID", "SAMPLE_TYPE", "SEQ_YEAR"]],
+            #self.genie_clinicaldf[["SAMPLE_ID", "SAMPLE_TYPE", "SEQ_YEAR"]],
+            self.genie_clinicaldf[["SAMPLE_ID", "SEQ_YEAR"]],
             on="SAMPLE_ID",
             how="left",
         )

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1368,11 +1368,12 @@ class BpcProjectRunner(metaclass=ABCMeta):
                 subset_sampledf[col] = years
 
         # Remove SAMPLE_TYPE and CPT_SEQ_DATE because the values are incorrect
-        del subset_sampledf["SAMPLE_TYPE"]
+        #del subset_sampledf["SAMPLE_TYPE"]
         del subset_sampledf["CPT_SEQ_DATE"]
         # Obtain this information from the main GENIE cohort
         subset_sampledf = subset_sampledf.merge(
-            self.genie_clinicaldf[["SAMPLE_ID", "SAMPLE_TYPE", "SEQ_YEAR"]],
+            #self.genie_clinicaldf[["SAMPLE_ID", "SAMPLE_TYPE", "SEQ_YEAR"]],
+            self.genie_clinicaldf[["SAMPLE_ID", "SEQ_YEAR"]],
             on="SAMPLE_ID",
             how="left",
         )

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1330,24 +1330,6 @@ class BpcProjectRunner(metaclass=ABCMeta):
             survival_info,
             "supp_survival_treatment",
         )
-        # Fill in ONCOTREE_CODE
-        # final_sampledf["ONCOTREE_CODE"] = [
-        #     self.genie_clinicaldf["ONCOTREE_CODE"][
-        #         self.genie_clinicaldf["SAMPLE_ID"] == sample
-        #     ].values[0]
-        #     if sum(self.genie_clinicaldf["SAMPLE_ID"] == sample) > 0
-        #     else float("nan")
-        #     for sample in final_sampledf["SAMPLE_ID"]
-        # ]
-        # # Fill in SEQ_ASSAY_ID
-        # final_sampledf["SEQ_ASSAY_ID"] = [
-        #     self.genie_clinicaldf["SEQ_ASSAY_ID"][
-        #         self.genie_clinicaldf["SAMPLE_ID"] == sample
-        #     ].values[0]
-        #     if sum(self.genie_clinicaldf["SAMPLE_ID"] == sample) > 0
-        #     else float("nan")
-        #     for sample in final_sampledf["SAMPLE_ID"]
-        # ]
 
         subset_sampledf = final_sampledf[
             final_sampledf["SAMPLE_ID"].isin(self.genie_clinicaldf["SAMPLE_ID"])
@@ -1368,11 +1350,9 @@ class BpcProjectRunner(metaclass=ABCMeta):
                 subset_sampledf[col] = years
 
         # Remove SAMPLE_TYPE and CPT_SEQ_DATE because the values are incorrect
-        #del subset_sampledf["SAMPLE_TYPE"]
         del subset_sampledf["CPT_SEQ_DATE"]
         # Obtain this information from the main GENIE cohort
         subset_sampledf = subset_sampledf.merge(
-            #self.genie_clinicaldf[["SAMPLE_ID", "SAMPLE_TYPE", "SEQ_YEAR"]],
             self.genie_clinicaldf[["SAMPLE_ID", "SEQ_YEAR"]],
             on="SAMPLE_ID",
             how="left",

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1368,12 +1368,11 @@ class BpcProjectRunner(metaclass=ABCMeta):
                 subset_sampledf[col] = years
 
         # Remove SAMPLE_TYPE and CPT_SEQ_DATE because the values are incorrect
-        #del subset_sampledf["SAMPLE_TYPE"]
+        del subset_sampledf["SAMPLE_TYPE"]
         del subset_sampledf["CPT_SEQ_DATE"]
         # Obtain this information from the main GENIE cohort
         subset_sampledf = subset_sampledf.merge(
-            #self.genie_clinicaldf[["SAMPLE_ID", "SAMPLE_TYPE", "SEQ_YEAR"]],
-            self.genie_clinicaldf[["SAMPLE_ID", "SEQ_YEAR"]],
+            self.genie_clinicaldf[["SAMPLE_ID", "SAMPLE_TYPE", "SEQ_YEAR"]],
             on="SAMPLE_ID",
             how="left",
         )


### PR DESCRIPTION
Fixes #75 

1. Do not attempt convert AGE_AT_SEQUENCING variable from days to years as it is already in years
2. ONCOTREE_CODE, SAMPLE_TYPE, and SEQ_ASSAY_ID now drawn from curated or derived BPC data rather than main GENIE repository to ensure consistency between cBioPortal files and clinical files for data release