### PR TITLE
[GEN-766, GEN-870] Retract using release files and use consortium release

### DIFF
--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -41,6 +41,7 @@ CBIO_FILEFORMATS_ALL = [
     "data_gene_matrix.txt",
     "data_cna_hg19.seg",
     "data_fusions.txt",
+    "data_sv.txt",
     "data_CNA.txt",
 ]
 

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -572,7 +572,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         # DECISION 06/2023: use the release file to do retractions
         # This is due to the most recent releases potentially having
         # samples retracted. The consortium release matched with the
-        # public release (14.6-consortium <-> 14.0-public) must be used
+        # public release (14.7-consortium <-> 14.0-public) must be used
         # due to SEQ_YEAR being used through the code.
         sample_synid = self.get_mg_synid(
             self._MG_RELEASE_SYNID, "data_clinical_sample.txt"

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1162,7 +1162,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         if sv_synid is not None:
             sv_ent = self.syn.get(sv_synid, followLink=True)
             svdf = pd.read_table(sv_ent.path, low_memory=False)
-            svdf = svdf[svdf["Sample_ID"].isin(keep_samples)]
+            svdf = svdf[svdf["Sample_Id"].isin(keep_samples)]
             sv_path = os.path.join(self._SPONSORED_PROJECT, "data_sv.txt")
             self.write_and_storedf(svdf, sv_path, used_entities=[sv_synid])
 

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1135,7 +1135,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
             str: file path to written data
         """
         # TODO: the seg filename will change 13.X release.
-        file_name = "genie_data_cna_hg19.seg"
+        file_name = "data_cna_hg19.seg"
         seg_synid = self.get_mg_synid(self._MG_RELEASE_SYNID, file_name)
         seg_ent = self.syn.get(seg_synid, followLink=True)
         segdf = pd.read_table(seg_ent.path, low_memory=False)

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -273,6 +273,7 @@ def get_drug_mapping(
                         mapping[label] = code
     # ! Remove this after DD and GRS is fixed
     mapping['Gemcitabine Hydrochloride'] = mapping['Gemcitabine HCL']
+    mapping['Doxorubicin Hydrochloride'] = mapping['Doxorubicin HCL']
     return mapping
 
 

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1790,7 +1790,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         df_sample_subset["AGE_AT_SEQUENCING"] = df_sample_subset[
             "AGE_AT_SEQUENCING"
         ].apply(math.floor)
-        # Remove SAMPLE_TYPE and CPT_SEQ_DATE because the values are incorrect
+        # Remove CPT_SEQ_DATE because the values are incorrect
         del df_sample_subset["CPT_SEQ_DATE"]
         # Obtain this information from the main GENIE cohort
         df_sample_subset = df_sample_subset.merge(

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -2121,7 +2121,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         self.create_and_write_maf(df_sample_final["SAMPLE_ID"])
         dict_cna = self.create_and_write_cna(df_sample_final["SAMPLE_ID"])
         self.create_and_write_genematrix(df_sample_final, dict_cna["cna_samples"])
-        self.create_and_write_fusion(df_sample_final["SAMPLE_ID"])
+        # self.create_and_write_fusion(df_sample_final["SAMPLE_ID"])
         self.create_and_write_seg(df_sample_final["SAMPLE_ID"])
         self.create_and_write_sv(df_sample_final["SAMPLE_ID"])
 

--- a/geniesp/metafiles.py
+++ b/geniesp/metafiles.py
@@ -210,6 +210,16 @@ def get_cbio_file_metadata(study_identifier: str, cbio_filename: str) -> dict:
             profile_description="Fusions",
             filename=cbio_filename,
         )
+    elif cbio_filename.startswith("data_sv"):
+        meta_dict = create_genomic_meta_file(
+            study_identifier=study_identifier,
+            alteration_type="STRUCTURAL_VARIANT",
+            datatype="SV",
+            stable_id="structural_variants",
+            profile_name="Structural Variants",
+            profile_description="Structural Variants.",
+            filename=cbio_filename,
+        )
     elif cbio_filename.startswith("data_mutations_extended"):
         meta_dict = create_genomic_meta_file(
             study_identifier=study_identifier,


### PR DESCRIPTION
* Retract using release files instead of using clinical tables
* Update to use 14.7-consortium for generating BLADDER v1.2
* Deprecate fusions
* Update SEG file name