### PR TITLE
[GEN-848, GEN-860] Add in ECOG values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /usr/src/GENIE-Sponsored-Projects
 COPY . .
 RUN pip install ./
 
-RUN git clone https://github.com/cBioPortal/cbioportal.git ../cbioportal
+RUN git clone https://github.com/cBioPortal/cbioportal.git -b v5.3.19 ../cbioportal

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -254,8 +254,8 @@ def get_drug_mapping(
         var_names.append("drugs_drug_" + i)
         var_names.append("drugs_drug_oth" + i)
 
-    for obj in dd, grs:
-
+    # for obj in dd, grs:
+    for obj in [dd]:
         for var_name in var_names:
 
             if var_name in obj["Variable / Field Name"].unique():
@@ -270,6 +270,8 @@ def get_drug_mapping(
                         value = pair.split(",")[1].strip()
                         label = value.split("(")[0].strip()
                         mapping[label] = code
+    # ! Remove this after DD and GRS is fixed
+    mapping['Gemcitabine Hydrochloride'] = mapping['Gemcitabine HCL']
     return mapping
 
 
@@ -610,9 +612,9 @@ class BpcProjectRunner(metaclass=ABCMeta):
             )
             release_folder = self.syn.store(Folder(self.release, parent=sp_data_folder))
             # if not self.upload:
-            #     release_folder = self.syn.store(
-            #         Folder("cBioPortal_files", parent=release_folder)
-            #     ).id
+            release_folder = self.syn.store(
+                Folder("cBioPortal_files", parent=release_folder)
+            ).id
             case_lists = self.syn.store(Folder("case_lists", parent=release_folder))
             return {"release": release_folder, "case_lists": case_lists}
         return {}
@@ -1240,8 +1242,8 @@ class BpcProjectRunner(metaclass=ABCMeta):
         timeline_infodf.index = timeline_infodf["code"]
         data = self.create_fixed_timeline_files(timeline_infodf, "TIMELINE-PERFORMANCE")
         # HACK: Due to remapping logic, we will re-create RESULT column with correct
-        has_md_karnof = ~data['df']['MD_KARNOF'].fillna('').str.startswith(("Not" ,"not"))
-        has_md_ecog = ~data['df']['MD_ECOG'].fillna('').str.startswith(("Not" ,"not"))
+        has_md_karnof = ~data['df']['MD_KARNOF'].fillna('Not').str.startswith(("Not" ,"not"))
+        has_md_ecog = ~data['df']['MD_ECOG'].fillna('Not').str.startswith(("Not" ,"not"))
         # Only add in values for SCORE_TYPE and RESULT when MD_KARNOF
         # and ECOG are present
         data['df']['SCORE_TYPE'] = ""

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -41,6 +41,7 @@ CBIO_FILEFORMATS_ALL = [
     "data_gene_matrix.txt",
     "data_cna_hg19.seg",
     "data_fusions.txt",
+    "data_sv.txt",
     "data_CNA.txt",
 ]
 

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -572,7 +572,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         # DECISION 06/2023: use the release file to do retractions
         # This is due to the most recent releases potentially having
         # samples retracted. The consortium release matched with the
-        # public release (14.6-consortium <-> 14.0-public) must be used
+        # public release (14.7-consortium <-> 14.0-public) must be used
         # due to SEQ_YEAR being used through the code.
         sample_synid = self.get_mg_synid(
             self._MG_RELEASE_SYNID, "data_clinical_sample.txt"

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -512,7 +512,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     _SPONSORED_PROJECT = ""
     # Redcap codes to cbioportal mapping synid and form key is in
     # version 38, 42 were last stable version(s)
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.48"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.49"
     # Run `git rev-parse HEAD` in Genie_processing directory to obtain shadigest
     _GITHUB_REPO = None
     # Mapping from Synapse Table to derived variables

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -512,7 +512,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     _SPONSORED_PROJECT = ""
     # Redcap codes to cbioportal mapping synid and form key is in
     # version 38, 42 were last stable version(s)
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.46"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.47"
     # Run `git rev-parse HEAD` in Genie_processing directory to obtain shadigest
     _GITHUB_REPO = None
     # Mapping from Synapse Table to derived variables

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1162,7 +1162,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         if sv_synid is not None:
             sv_ent = self.syn.get(sv_synid, followLink=True)
             svdf = pd.read_table(sv_ent.path, low_memory=False)
-            svdf = svdf[svdf["Sample_ID"].isin(keep_samples)]
+            svdf = svdf[svdf["Sample_Id"].isin(keep_samples)]
             sv_path = os.path.join(self._SPONSORED_PROJECT, "data_sv.txt")
             self.write_and_storedf(svdf, sv_path, used_entities=[sv_synid])
 

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -507,8 +507,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     # Sponsored project name
     _SPONSORED_PROJECT = ""
     # Redcap codes to cbioportal mapping synid and form key is in
-    # version 38 was the last stable version
-    # Use version 42 - but there is a bug in Synapse...
+    # version 38, 42 were last stable version(s)
     _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693"
     # Run `git rev-parse HEAD` in Genie_processing directory to obtain shadigest
     _GITHUB_REPO = None

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -510,7 +510,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     _SPONSORED_PROJECT = ""
     # Redcap codes to cbioportal mapping synid and form key is in
     # version 38, 42 were last stable version(s)
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.46"
     # Run `git rev-parse HEAD` in Genie_processing directory to obtain shadigest
     _GITHUB_REPO = None
     # Mapping from Synapse Table to derived variables

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -516,8 +516,8 @@ class BpcProjectRunner(metaclass=ABCMeta):
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples
     _SP_REDCAP_EXPORTS_SYNID = "syn21446571"
-    # main GENIE release folder (12.0-public)
-    _MG_RELEASE_SYNID = "syn32309524"
+    # main GENIE release folder (14.0-public)
+    _MG_RELEASE_SYNID = "syn52433756"
     # PRISSMM documentation table
     _PRISSMM_SYNID = "syn22684834"
     # REDCap global response set

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -85,7 +85,7 @@ def get_file_data(
         if sampletype == "SAMPLE":
             cols.append("path_proc_number")
         # Only get specific cohort and subset cols
-        tabledf = pd.read_csv(table.path, low_memory=False, encoding='ISO-8859-1')
+        tabledf = pd.read_csv(table.path, low_memory=False)
         tabledf = tabledf[tabledf["cohort"] == cohort]
         tabledf = tabledf[cols]
         # Append to final dataframe if empty

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1135,7 +1135,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
             str: file path to written data
         """
         # TODO: the seg filename will change 13.X release.
-        file_name = "genie_data_cna_hg19.seg"
+        file_name = "data_cna_hg19.seg"
         seg_synid = self.get_mg_synid(self._MG_RELEASE_SYNID, file_name)
         seg_ent = self.syn.get(seg_synid, followLink=True)
         segdf = pd.read_table(seg_ent.path, low_memory=False)

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -520,9 +520,9 @@ class BpcProjectRunner(metaclass=ABCMeta):
     _DATA_TABLE_IDS = "syn22296821"
     # Storage of not found samples
     _SP_REDCAP_EXPORTS_SYNID = "syn21446571"
-    # main GENIE release folder (14.7-consortium)
+    # main GENIE release folder (14.8-consortium)
     # Must use consortium release, because SEQ_YEAR is used
-    _MG_RELEASE_SYNID = "syn52414666"
+    _MG_RELEASE_SYNID = "syn52794528"
     # PRISSMM documentation table
     _PRISSMM_SYNID = "syn22684834"
     # REDCap global response set

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -890,7 +890,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         )
 
         # Make sure all events types are treatment
-        final_timelinedf["EVENT_TYPE"] = "Treatment"
+        final_timelinedf["EVENT_TYPE"] = "TREATMENT"
 
         # Make sure AGENT is not null and doesn't have parenthesis
         agents = []
@@ -1317,7 +1317,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         rad_df = treatment_rad_data["df"]
         rad_df["STOP_DATE"] = rad_df["START_DATE"] + rad_df["TEMP"]
         rad_df = rad_df[rad_df["INDEX_CANCER"] == "Yes"]
-        rad_df["EVENT_TYPE"] = "Treatment"
+        rad_df["EVENT_TYPE"] = "TREATMENT"
         rad_df["TREATMENT_TYPE"] = "Radiation Therapy"
         del rad_df["INDEX_CANCER"]
         del rad_df["TEMP"]

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -512,7 +512,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     _SPONSORED_PROJECT = ""
     # Redcap codes to cbioportal mapping synid and form key is in
     # version 38, 42 were last stable version(s)
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.47"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.48"
     # Run `git rev-parse HEAD` in Genie_processing directory to obtain shadigest
     _GITHUB_REPO = None
     # Mapping from Synapse Table to derived variables

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -273,6 +273,7 @@ def get_drug_mapping(
                         mapping[label] = code
     # ! Remove this after DD and GRS is fixed
     mapping['Gemcitabine Hydrochloride'] = mapping['Gemcitabine HCL']
+    mapping['Doxorubicin Hydrochloride'] = mapping['Doxorubicin HCL']
     return mapping
 
 

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1790,7 +1790,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         df_sample_subset["AGE_AT_SEQUENCING"] = df_sample_subset[
             "AGE_AT_SEQUENCING"
         ].apply(math.floor)
-        # Remove SAMPLE_TYPE and CPT_SEQ_DATE because the values are incorrect
+        # Remove CPT_SEQ_DATE because the values are incorrect
         del df_sample_subset["CPT_SEQ_DATE"]
         # Obtain this information from the main GENIE cohort
         df_sample_subset = df_sample_subset.merge(

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -2121,7 +2121,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         self.create_and_write_maf(df_sample_final["SAMPLE_ID"])
         dict_cna = self.create_and_write_cna(df_sample_final["SAMPLE_ID"])
         self.create_and_write_genematrix(df_sample_final, dict_cna["cna_samples"])
-        self.create_and_write_fusion(df_sample_final["SAMPLE_ID"])
+        # self.create_and_write_fusion(df_sample_final["SAMPLE_ID"])
         self.create_and_write_seg(df_sample_final["SAMPLE_ID"])
         self.create_and_write_sv(df_sample_final["SAMPLE_ID"])
 

--- a/geniesp/metafiles.py
+++ b/geniesp/metafiles.py
@@ -210,6 +210,16 @@ def get_cbio_file_metadata(study_identifier: str, cbio_filename: str) -> dict:
             profile_description="Fusions",
             filename=cbio_filename,
         )
+    elif cbio_filename.startswith("data_sv"):
+        meta_dict = create_genomic_meta_file(
+            study_identifier=study_identifier,
+            alteration_type="STRUCTURAL_VARIANT",
+            datatype="SV",
+            stable_id="structural_variants",
+            profile_name="Structural Variants",
+            profile_description="Structural Variants.",
+            filename=cbio_filename,
+        )
     elif cbio_filename.startswith("data_mutations_extended"):
         meta_dict = create_genomic_meta_file(
             study_identifier=study_identifier,


### PR DESCRIPTION
This adds in support for the ECOG values.  That said, prior to merging this in, we should make sure the mapping file is updated through the proper channels.  I recommend the mapping file be in this [structure](https://www.synapse.org/#!Synapse:syn25712693/tables/query/eyJzcWwiOiJTRUxFQ1QgKiBGUk9NIHN5bjI1NzEyNjkzIiwgInNlbGVjdGVkRmFjZXRzIjpbeyJjb25jcmV0ZVR5cGUiOiJvcmcuc2FnZWJpb25ldHdvcmtzLnJlcG8ubW9kZWwudGFibGUuRmFjZXRDb2x1bW5WYWx1ZXNSZXF1ZXN0IiwgImNvbHVtbk5hbWUiOiJzYW1wbGVUeXBlIiwgImZhY2V0VmFsdWVzIjpbIlRJTUVMSU5FLVBFUkZPUk1BTkNFIl19XSwgImluY2x1ZGVFbnRpdHlFdGFnIjp0cnVlLCAib2Zmc2V0IjowLCAibGltaXQiOjI1fQ==).

The extra data transformations are documented within code.  We can decide whether or not we want to have a document that  outlines all the transformations on a per file basis.

Note: I also encountered the encoding issue, so there is a fix in there for that.  Currently unsure of downstream implications, but it "seems" ok