### PR TITLE
[GEN-1004] Update bpc_redcap_export_mapping.py

### DIFF
--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -502,7 +502,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     _SPONSORED_PROJECT = ""
     # Redcap codes to cbioportal mapping synid and form key is in
     # version 38, 42 were last stable version(s)
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.49"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.50"
     # Run `git rev-parse HEAD` in Genie_processing directory to obtain shadigest
     _GITHUB_REPO = None
     # Mapping from Synapse Table to derived variables


### PR DESCRIPTION
Updating to use v50 of mapping table (from v49) to get the changes needed for the bladder 1.2-consortium release.