### PR TITLE
[GEN-1240] Add GRS toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,15 @@ optional arguments:
                         Optional parameter to specify cbioportal folder
                         location
   --production          Whether to run in production mode or not. Default: false
+  --use-grs             Whether to use grs or use dd as primary mapping. Default: false
 ```
 
 Example command line:
 
-This runs the release pipeline for BLADDER 1.1 in non-production mode (staging).
+This runs the release pipeline for BLADDER 1.1 in non-production mode (staging) with GRS enabled.
 
 ```
-geniesp BLADDER 1.1-consortium --upload
+geniesp BLADDER 1.1-consortium --upload --use-grs
 ```
 
 Example command using docker:

--- a/geniesp/__main__.py
+++ b/geniesp/__main__.py
@@ -49,6 +49,17 @@ def main():
         type=str,
         help="Optional parameter to specify cbioportal folder location",
     )
+    parser.add_argument(
+        "--production",
+        action="store_true",
+        help="Use production project or not (staging). Default: false.",
+    )
+    parser.add_argument(
+        "--use-grs",
+        type=bool,
+        default=False,
+        help="Whether to use grs as primary mapping (dd as secondary) or not (using dd only).",
+    )
     args = parser.parse_args()
 
     numeric_level = getattr(logging, args.log.upper(), None)
@@ -63,7 +74,14 @@ def main():
     else:
         cbiopath = args.cbioportal
 
-    BPC_MAPPING[args.sp](syn, cbiopath, release=args.release, upload=args.upload).run()
+    BPC_MAPPING[args.sp](
+        syn, 
+        cbiopath, 
+        release=args.release, 
+        upload=args.upload, 
+        production = args.production, 
+        use_grs = args.use_grs
+    ).run()
 
 
 if __name__ == "__main__":

--- a/geniesp/__main__.py
+++ b/geniesp/__main__.py
@@ -56,9 +56,8 @@ def main():
     )
     parser.add_argument(
         "--use-grs",
-        type=bool,
-        default=False,
-        help="Whether to use grs as primary mapping (dd as secondary) or not (using dd only).",
+        action="store_true",
+        help="Whether to use grs or use dd as primary mapping.",
     )
     args = parser.parse_args()
 
@@ -75,7 +74,7 @@ def main():
         cbiopath = args.cbioportal
 
     BPC_MAPPING[args.sp](
-        syn, 
+        syn,
         cbiopath, 
         release=args.release, 
         upload=args.upload, 

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -1733,7 +1733,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
         return {"df": subset_survivaldf[cols_to_order], "survival_info": survival_info}
 
     def get_survival_treatment(
-        self, df_map: pd.DataFrame, df_file: pd.DataFrame
+        self, df_map: pd.DataFrame, df_file: pd.DataFrame,
     ) -> pd.DataFrame:
         """Get SURVIVAL and REGIMEN file data.
 
@@ -1755,6 +1755,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
             cohort=self._SPONSORED_PROJECT,
             synid_file_grs=self._GRS_SYNID,
             synid_table_prissmm=self._PRISSMM_SYNID,
+            use_grs=self.use_grs,
         )
         regimens_data = create_regimens(
             self.syn,
@@ -2163,7 +2164,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
 
         logging.info("writing CLINICAL-SURVIVAL-TREATMENT...")
         df_survival_treatment = self.get_survival_treatment(
-            df_map=redcap_to_cbiomappingdf, df_file=data_tablesdf
+            df_map=redcap_to_cbiomappingdf, df_file=data_tablesdf,
         )
         surv_treatment_path = self.write_clinical_file(
             df_survival_treatment,

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -282,7 +282,13 @@ def parse_drug_mappings(mapping: pd.DataFrame, var_names: List[str]) -> Dict[str
     """
     mappings = {}
     # Rename columns for easier access
-    mapping.columns = ["Variable / Field Name", "Choices, Calculations, OR Slider Labels"]
+    mapping = mapping.rename(
+        columns={
+            mapping.columns[0]: "Variable / Field Name", 
+            mapping.columns[1]: "Choices, Calculations, OR Slider Labels"
+            }
+        )
+    mapping = mapping[["Variable / Field Name", "Choices, Calculations, OR Slider Labels"]]
 
     for var_name in var_names:
         if var_name in mapping["Variable / Field Name"].unique():

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -281,13 +281,8 @@ def parse_drug_mappings(mapping: pd.DataFrame, var_names: List[str]) -> Dict[str
                 corresponding NCIT drug code
     """
     mappings = {}
-    # Rename columns for easier access
-    mapping = mapping.rename(
-        columns={
-            mapping.columns[0]: "Variable / Field Name", 
-            mapping.columns[1]: "Choices, Calculations, OR Slider Labels"
-            }
-        )
+    # dd has more than 2 columns and not all columns start with these two.
+    # going to just subset to the required columns.
     mapping = mapping[["Variable / Field Name", "Choices, Calculations, OR Slider Labels"]]
 
     for var_name in var_names:

--- a/main.nf
+++ b/main.nf
@@ -18,20 +18,33 @@ process cBioPortalExport {
    stdout
 
    script:
-   if (production) {
+   if (production && use_grs) {
       """
       geniesp $cohort $release \
          --upload \
          --cbioportal /usr/src/cbioportal \
          --production \
-         --use_grs $use_grs
+         --use-grs
+      """
+   } else if (production && !use_grs){
+      """
+      geniesp $cohort $release \
+         --upload \
+         --cbioportal /usr/src/cbioportal \
+         --production
+      """
+   } else if (!production && use_grs){
+      """
+      geniesp $cohort $release \
+         --upload \
+         --cbioportal /usr/src/cbioportal \
+         --use-grs
       """
    } else {
       """
       geniesp $cohort $release \
          --upload \
          --cbioportal /usr/src/cbioportal \
-         --use_grs $use_grs
       """
    }
 }

--- a/main.nf
+++ b/main.nf
@@ -12,18 +12,27 @@ process cBioPortalExport {
    val cohort
    val release
    val upload
+   val production
+   val use_grs
 
    output:
    stdout
 
    script:
-   if ( upload ) {
+   if (production) {
       """
-      geniesp $cohort $release --upload --cbioportal /usr/src/cbioportal
+      geniesp $cohort $release \
+         --upload \
+         --cbioportal /usr/src/cbioportal \
+         --production \
+         --use_grs $use_grs
       """
    } else {
       """
-      geniesp $cohort $release --cbioportal /usr/src/cbioportal
+      geniesp $cohort $release \
+         --upload \
+         --cbioportal /usr/src/cbioportal \
+         --use_grs $use_grs
       """
    }
 }
@@ -32,6 +41,8 @@ workflow {
    params.cohort = 'NSCLC' // Default
    params.release = '1.1-consortium'  // Default
    params.upload = false  // Default
+   params.production = false
+   params.use_grs = false
 
    // Check if cohort is part of allowed cohort list
    def allowed_cohorts = ["BLADDER", "BrCa", "CRC", "NSCLC", "PANC", "Prostate"]
@@ -40,6 +51,8 @@ workflow {
    ch_cohort = Channel.value(params.cohort)
    ch_release = Channel.value(params.release)
    ch_upload = Channel.value(params.upload)
+   ch_production = Channel.value(params.production)
+   ch_use_grs = Channel.value(params.use_grs)
 
-   cBioPortalExport(ch_cohort, ch_release, ch_upload)
+   cBioPortalExport(ch_cohort, ch_release, ch_upload, ch_production, ch_use_grs)
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,0 +1,69 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/Sage-Bionetworks/GENIE-Sponsored-Projects/develop/nextflow_schema.json",
+    "title": "Sage-Bionetworks/GENIE-Sponsored-Projects parameters",
+    "description": "Nextflow pipeline for BPC cBioportal release",
+    "type": "object",
+    "definitions": {
+        "parameters": {
+            "title": "Input options",
+            "type": "object",
+            "fa_icon": "fas fa-terminal",
+            "description": "Define BPC cBioportal release pipeline parameters.",
+            "properties": {
+                "cohort": {
+                    "type": "string",
+                    "default": "NSCLC",
+                    "description": "Name of the cohort to release for BPC.",
+                    "enum": [
+                        "BLADDER",
+                        "BrCa",
+                        "CRC",
+                        "NSCLC",
+                        "PANC",
+                        "Prostate",
+                        "CRC2",
+                        "NSCLC2",
+                        "MELANOMA",
+                        "OVARIAN",
+                        "ESOPHAGO",
+                        "RENAL"
+                    ]
+                },
+                "release": {
+                    "type": "string",
+                    "description": "Name for this BPC cBioportal release",
+                    "default": "1.1-consortium"
+                },
+                "production": {
+                    "type": "boolean",
+                    "description": "Whether to run in production mode or not. Production mode means uploading to Synapse.",
+                    "default": false,
+                    "enum": [
+                        true,
+                        false
+                    ]
+                },
+                "use_grs": {
+                    "type": "boolean",
+                    "description": "Whether to use grs as primary mapping (dd as secondary) or not (using dd only). ",
+                    "default": false,
+                    "enum": [
+                        true,
+                        false
+                    ]
+                },
+                "help": {
+                    "type": "boolean",
+                    "description": "Display input options and descriptions",
+                    "default": false
+                }
+            }
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "#/definitions/parameters"
+        }
+    ]
+}

--- a/tests/test_bpc_redcap_export_mapping.py
+++ b/tests/test_bpc_redcap_export_mapping.py
@@ -73,16 +73,6 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
             pd.DataFrame(
                 {
                     "Variable / Field Name": ["drugs_drug_1"],
-                    "Choices, Calculations, OR Slider Labels": ["D001, Aspirin | D002, Ibuprofen | D003, Paracetamol"],
-                }
-            ),
-            ["drugs_drug_1"],
-            {"Aspirin": "D001", "Ibuprofen": "D002", "Paracetamol": "D003"},
-        ),
-        (
-            pd.DataFrame(
-                {
-                    "Variable / Field Name": ["drugs_drug_1"],
                     "Choices, Calculations, OR Slider Labels": ["D001, Aspirin|"],
                 }
             ),
@@ -115,7 +105,6 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
     ],
     ids=[
         "multiple_drug_vars",
-        "diff_var_names",
         "empty_split",
         "nothing_to_parse",
         "parenthesis_split",

--- a/tests/test_bpc_redcap_export_mapping.py
+++ b/tests/test_bpc_redcap_export_mapping.py
@@ -106,7 +106,7 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
                     "Choices, Calculations, OR Slider Labels": [
                         "D001, Aspirin (alternative) | D002, Ibuprofen | D003, Paracetamol"
                     ],
-                    "extra_column" : ["test1", "test2"]
+                    "extra_column" : ["test1"]
                 }
             ),
             ["drugs_drug_1"],

--- a/tests/test_bpc_redcap_export_mapping.py
+++ b/tests/test_bpc_redcap_export_mapping.py
@@ -1,0 +1,84 @@
+import pytest
+from pytest import mock
+
+import pandas as pd
+import synapseclient
+
+from geniesp import bpc_redcap_export_mapping as bpc_export
+
+
+@pytest.fixture
+def mock_syn():
+    yield mock.Mock(spec=synapseclient.Synapse)
+
+
+def test_that_get_drug_variable_names_gets_expected_list():
+    var_names = bpc_export.get_drug_variable_names()
+    assert var_names == [
+        "drugs_drug_1",
+        "drugs_drug_oth1" "drugs_drug_2",
+        "drugs_drug_oth2" "drugs_drug_3",
+        "drugs_drug_oth3" "drugs_drug_4",
+        "drugs_drug_oth4" "drugs_drug_5",
+        "drugs_drug_oth5",
+    ]
+
+
+def test_get_mapping_data_calls_grs_if_use_grs_is_true(mock_syn):
+    with mock.patch.object(mock_syn, "get") as mock_get, mock.patch.object(
+        pd, "read_csv"
+    ):
+        bpc_export.get_mapping_data(
+            syn=mock_syn, synid_file_grs="synGRS", synid_file_dd="synDD", use_grs=True
+        )
+        mock_get.assert_called_with("synGRS")
+
+
+def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
+    with mock.patch.object(mock_syn, "get") as mock_get, mock.patch.object(
+        pd, "read_csv"
+    ):
+        bpc_export.get_mapping_data(
+            syn=mock_syn, synid_file_grs="synGRS", synid_file_dd="synDD", use_grs=False
+        )
+        mock_get.assert_called_with("synDD")
+
+
+@pytest.mark.parametrize(
+    "input_mapping, var_names, output_mapping"[
+        (
+            pd.DataFrame(
+                {
+                    "Variable / Field Name": "drugs_drug_1",
+                    "Choices, Calculations, OR Slider Labels": "D001, Aspirin | D002, Ibuprofen | D003, Paracetamol",
+                }
+            ),
+            ["drugs_drug_1"],
+            {"D001": "Aspirin", "D002": "Ibuprofen", "D003": "Paracetamol"},
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "variable": "drugs_drug_1",
+                    "labels": "D001, Aspirin | D002, Ibuprofen | D003, Paracetamol",
+                }
+            ),
+            ["drugs_drug_1"],
+            {"D001": "Aspirin", "D002": "Ibuprofen", "D003": "Paracetamol"},
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "variable": "ethnicity",
+                    "labels": "1",
+                }
+            ),
+            ["drugs_drug_1"],
+            {},
+        ),
+    ],
+    ids=["", "nothing to parse", ""],
+)
+def test_that_parse_drug_mappings(input_mapping, var_names, output_mapping):
+    result = bpc_export.parse_drug_mappings(mapping=input_mapping, var_names=var_names)
+    assert result == output_mapping

--- a/tests/test_bpc_redcap_export_mapping.py
+++ b/tests/test_bpc_redcap_export_mapping.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest import mock
+from unittest import mock
 
 import pandas as pd
 import synapseclient
@@ -16,10 +16,14 @@ def test_that_get_drug_variable_names_gets_expected_list():
     var_names = bpc_export.get_drug_variable_names()
     assert var_names == [
         "drugs_drug_1",
-        "drugs_drug_oth1" "drugs_drug_2",
-        "drugs_drug_oth2" "drugs_drug_3",
-        "drugs_drug_oth3" "drugs_drug_4",
-        "drugs_drug_oth4" "drugs_drug_5",
+        "drugs_drug_oth1",
+        "drugs_drug_2",
+        "drugs_drug_oth2",
+        "drugs_drug_3",
+        "drugs_drug_oth3",
+        "drugs_drug_4",
+        "drugs_drug_oth4",
+        "drugs_drug_5",
         "drugs_drug_oth5",
     ]
 
@@ -45,39 +49,76 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
 
 
 @pytest.mark.parametrize(
-    "input_mapping, var_names, output_mapping"[
+    "input_mapping, var_names, output_mapping",
+    [
         (
             pd.DataFrame(
                 {
-                    "Variable / Field Name": "drugs_drug_1",
-                    "Choices, Calculations, OR Slider Labels": "D001, Aspirin | D002, Ibuprofen | D003, Paracetamol",
+                    "Variable / Field Name": ["drugs_drug_1", "drugs_drug_2"],
+                    "Choices, Calculations, OR Slider Labels": [
+                        "D001, Aspirin | D002, Ibuprofen | D003, Paracetamol",
+                        "D004, Tylenol |",
+                    ],
                 }
             ),
-            ["drugs_drug_1"],
-            {"D001": "Aspirin", "D002": "Ibuprofen", "D003": "Paracetamol"},
+            ["drugs_drug_1", "drugs_drug_2"],
+            {
+                "Aspirin": "D001",
+                "Ibuprofen": "D002",
+                "Paracetamol": "D003",
+                "Tylenol": "D004",
+            },
         ),
         (
             pd.DataFrame(
                 {
-                    "variable": "drugs_drug_1",
-                    "labels": "D001, Aspirin | D002, Ibuprofen | D003, Paracetamol",
+                    "variable": ["drugs_drug_1"],
+                    "labels": ["D001, Aspirin | D002, Ibuprofen | D003, Paracetamol"],
                 }
             ),
             ["drugs_drug_1"],
-            {"D001": "Aspirin", "D002": "Ibuprofen", "D003": "Paracetamol"},
+            {"Aspirin": "D001", "Ibuprofen": "D002", "Paracetamol": "D003"},
         ),
         (
             pd.DataFrame(
                 {
-                    "variable": "ethnicity",
-                    "labels": "1",
+                    "variable": ["drugs_drug_1"],
+                    "labels": ["D001, Aspirin|"],
+                }
+            ),
+            ["drugs_drug_1"],
+            {"Aspirin": "D001"},
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "variable": ["ethnicity"],
+                    "labels": ["1"],
                 }
             ),
             ["drugs_drug_1"],
             {},
         ),
+        (
+            pd.DataFrame(
+                {
+                    "variable": ["drugs_drug_1"],
+                    "labels": [
+                        "D001, Aspirin (alternative) | D002, Ibuprofen | D003, Paracetamol"
+                    ],
+                }
+            ),
+            ["drugs_drug_1"],
+            {"Aspirin": "D001", "Ibuprofen": "D002", "Paracetamol": "D003"},
+        ),
     ],
-    ids=["", "nothing to parse", ""],
+    ids=[
+        "multiple_drug_vars",
+        "diff_var_names",
+        "empty_split",
+        "nothing_to_parse",
+        "parenthesis_split",
+    ],
 )
 def test_that_parse_drug_mappings(input_mapping, var_names, output_mapping):
     result = bpc_export.parse_drug_mappings(mapping=input_mapping, var_names=var_names)

--- a/tests/test_bpc_redcap_export_mapping.py
+++ b/tests/test_bpc_redcap_export_mapping.py
@@ -72,8 +72,8 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
         (
             pd.DataFrame(
                 {
-                    "variable": ["drugs_drug_1"],
-                    "labels": ["D001, Aspirin | D002, Ibuprofen | D003, Paracetamol"],
+                    "Variable / Field Name": ["drugs_drug_1"],
+                    "Choices, Calculations, OR Slider Labels": ["D001, Aspirin | D002, Ibuprofen | D003, Paracetamol"],
                 }
             ),
             ["drugs_drug_1"],
@@ -83,7 +83,7 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
             pd.DataFrame(
                 {
                     "variable": ["drugs_drug_1"],
-                    "labels": ["D001, Aspirin|"],
+                    "choices": ["D001, Aspirin|"],
                 }
             ),
             ["drugs_drug_1"],
@@ -93,7 +93,7 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
             pd.DataFrame(
                 {
                     "variable": ["ethnicity"],
-                    "labels": ["1"],
+                    "choices": ["1"],
                 }
             ),
             ["drugs_drug_1"],
@@ -102,10 +102,11 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
         (
             pd.DataFrame(
                 {
-                    "variable": ["drugs_drug_1"],
-                    "labels": [
+                    "Variable / Field Name": ["drugs_drug_1"],
+                    "Choices, Calculations, OR Slider Labels": [
                         "D001, Aspirin (alternative) | D002, Ibuprofen | D003, Paracetamol"
                     ],
+                    "extra_column" : ["test1", "test2"]
                 }
             ),
             ["drugs_drug_1"],

--- a/tests/test_bpc_redcap_export_mapping.py
+++ b/tests/test_bpc_redcap_export_mapping.py
@@ -82,8 +82,8 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
         (
             pd.DataFrame(
                 {
-                    "variable": ["drugs_drug_1"],
-                    "choices": ["D001, Aspirin|"],
+                    "Variable / Field Name": ["drugs_drug_1"],
+                    "Choices, Calculations, OR Slider Labels": ["D001, Aspirin|"],
                 }
             ),
             ["drugs_drug_1"],
@@ -92,8 +92,8 @@ def test_get_mapping_data_calls_dd_if_use_grs_is_false(mock_syn):
         (
             pd.DataFrame(
                 {
-                    "variable": ["ethnicity"],
-                    "choices": ["1"],
+                    "Variable / Field Name": ["ethnicity"],
+                    "Choices, Calculations, OR Slider Labels": ["1"],
                 }
             ),
             ["drugs_drug_1"],


### PR DESCRIPTION
**Purpose:** This PR is a draft PR but majority of the code design is present. At times we would like to use the data dictionary (dd) as the primary mapping for a dataset over the combined mapping of dd and global response set (grs) for particular cohorts. This PR adds the ability to specify a `use_grs` parameter for whether we should use grs or not for the cohort.

This is specific only to the bpc export step. This is the 2nd PR in a series. [See 1st part PR](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/pull/162)

**Changes:** 

- Added `use_grs` parameters and logic to support that

- Converted `get_drug_mapping` into series of helper functions for easier testability for the use of the grs vs dd mapping:
    - get_mapping_data
    - get_drug_variable_names
    - parse_drug_mappings


**Testing:**
- [x] Unit tests
- [x] Run `BPC cBioportal export` workflow with `use_grs` on staging and compare to production run in develop (should be the same result) 
- [x] Run `BPC cBioportal export` workflow **without** `use_grs` and compare to production run in develop (should have mapping differences)

Depends on #142 
Depends on #143