### PR TITLE
[GEN-1612] Use newest mapping table version 56 for CRC 3.1

### DIFF
--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -522,7 +522,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     # Redcap codes to cbioportal mapping synid and form key is in
     # version 38, 42 were last stable version(s)
     # NOTE: Should be pointed towards latest version of table
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.55"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.56"
     # Run `git rev-parse HEAD` in Genie_processing directory to obtain shadigest
     _GITHUB_REPO = None
     # Mapping from Synapse Table to derived variables


### PR DESCRIPTION
**Purpose:** Using version [56](https://www.synapse.org/Synapse:syn25712693.56) of the [BPC REDCap to cbio mapping](https://www.synapse.org/Synapse:syn25712693/tables/) table. This version contains the following changes since the previous update:

- Correction to duplicate `code` variable values of `mmr_result` by removing the rows that mapped to `MMR_RESULT_2` and `MMR_RESULT_3` as those won't be released due to minimal data