### PR TITLE
Fix _STAGING_RELEASES_FOLDER param

### DIFF
--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -514,7 +514,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     """BPC redcap to cbioportal export"""
     
     _STAGING_RELEASES_FOLDER = {
-        "production:": "syn50876969",
+        "production": "syn50876969",
         "staging":"syn64018253"
     }
     # Sponsored project name


### PR DESCRIPTION
**Purpose:**  Getting following error in nextflow when running CRC 3.1 release for production: 
```  Traceback (most recent call last):
    File "/usr/local/bin/geniesp", line 8, in <module>
      sys.exit(main())
    File "/usr/local/lib/python3.8/site-packages/geniesp/__main__.py", line 71, in main
      BPC_MAPPING[args.sp](
    File "/usr/local/lib/python3.8/site-packages/geniesp/bpc_redcap_export_mapping.py", line 1992, in run
      self.write_and_storedf(
    File "/usr/local/lib/python3.8/site-packages/geniesp/bpc_redcap_export_mapping.py", line 1002, in write_and_storedf
      ent = File(filepath, parent=self.cbioportal_folders["release"])
    File "/usr/local/lib/python3.8/functools.py", line 967, in __get__
      val = self.func(instance)
    File "/usr/local/lib/python3.8/site-packages/geniesp/bpc_redcap_export_mapping.py", line 661, in cbioportal_folders
      parentId=self._STAGING_RELEASES_FOLDER[self.environment]
  KeyError: 'production'
```
This is just due to `_STAGING_RELEASES_FOLDER` key for production being incorrect