### PR TITLE
[GEN-2274] Update bpc_redcap_export_mapping.py

### DIFF
--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -689,7 +689,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     # NOTE: Must use consortium release, because SEQ_DATE is used
     # NOTE: Must match release tracking sheet and release table info
     # for the given cohort
-    _MG_RELEASE_SYNID = "syn51719445"
+    _MG_RELEASE_SYNID = "syn68707900"
     # PRISSMM documentation table
     _PRISSMM_SYNID = "syn22684834"
     # REDCap global response set


### PR DESCRIPTION
Updating to use main genie release 18.0-public instead of 14.6-consortium release.

# **Problem:**

There are 10 RENAL samples missing from the cBioPortal files. This appears to be because they are not included in the 14.6-consortium release. The samples were filtered out since the cBio files were linked to 14.6 instead of the latest public release.

# **Solution:**

Update _MG_RELEASE_SYNID to link to the latest public release (18.0-public) syn68707900

# **Testing:**

None