### PR TITLE
Update bpc_redcap_export_mapping.py

### DIFF
--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -688,7 +688,7 @@ class BpcProjectRunner(metaclass=ABCMeta):
     # Redcap codes to cbioportal mapping synid and form key is in
     # version 38, 42 were last stable version(s)
     # NOTE: Should be pointed towards latest version of table
-    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.77"
+    _REDCAP_TO_CBIOMAPPING_SYNID = "syn25712693.65"
     # Run `git rev-parse HEAD` in Genie_processing directory to obtain shadigest
     _GITHUB_REPO = None
     # Mapping from Synapse Table to derived variables


### PR DESCRIPTION
Updating for BrCa 1.0-public and RENAL 1.1-consortium releases

Using mapping table v65 using mapping file (syn25585554.78)
