### PR TITLE
[GEN-2672] Fix CPT_SEQ_DATE replacement function

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,48 @@ do the cpt_seq_date replacement
 docker run --rm -e SYNAPSE_AUTH_TOKEN=$SYNAPSE_AUTH_TOKEN geniesp geniesp PANC 1.1-consortium --upload
 ```
 
+> **Note:** The positional cohort argument runs for the *entire* sponsored project subset,
+> including any expansion versions. For example, running for `CRC` processes **both** `CRC`
+> and `CRC2` samples (and running for `NSCLC` processes both `NSCLC` and `NSCLC2`). There is
+> no separate command to run only the expansion. See
+> [Cohort subsetting: `cohort` vs `cohort_internal`](#cohort-subsetting-cohort-vs-cohort_internal)
+> below for details.
+
+## Cohort subsetting: `cohort` vs `cohort_internal`
+
+Some BPC cohorts have expansion releases that are curated as a separate version but
+released together under the same sponsored project. For example, `CRC` and `CRC2`, and
+`NSCLC` and `NSCLC2`, are distinct curated versions that belong to the **same** sponsored
+project subset (`CRC` and `NSCLC` respectively).
+
+The derived variable file (used to replace `CPT_SEQ_DATE`) encodes this
+distinction with two columns:
+
+- `cohort` — the version-specific label. This differentiates the expansion, e.g.
+  `NSCLC` vs `NSCLC2`.
+- `cohort_internal` — the umbrella label for the whole sponsored project. Both `NSCLC`
+  and `NSCLC2` rows share `cohort_internal == "NSCLC"`.
+
+| SAMPLE_ID           | `cohort` | `cohort_internal` |
+| ------------------- | -------- | ----------------- |
+| GENIE-SAGE-1 (CRC)  | `CRC`    | `CRC`             |
+| GENIE-SAGE-2 (CRC2) | `CRC2`   | `CRC`             |
+
+**Why the pipeline filters on `cohort_internal`:** when running the pipeline for a
+sponsored project (e.g. `NSCLC`), the clinical sample data being released includes samples
+from *both* the original and the expansion version (`NSCLC` and `NSCLC2`). To replace
+`CPT_SEQ_DATE` for all of those samples, the derived variable file must be subset to
+include both versions — which only `cohort_internal == "NSCLC"` does.
+
+If we filtered on `cohort == "NSCLC"` instead, the `NSCLC2` rows would be dropped from the
+replacement data. During the left merge on `SAMPLE_ID` in `replace_cpt_seq_date`, every
+`NSCLC2` sample would then fail to find a match and receive a missing (`NaN`)
+`CPT_SEQ_DATE`. For this reason the pipeline subsets the derived variable file using
+`cohort_internal` (see `get_derived_variable_file` in
+[geniesp/bpc_redcap_export_mapping.py](geniesp/bpc_redcap_export_mapping.py)), and
+`check_seq_date_replacement` warns if a good chunk of `CPT_SEQ_DATE` values are missing after the
+replacement.
+
 ## Scripts
 
 To validate a cBioPortal mapping file stored on synapse:

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -501,7 +501,7 @@ def get_derived_variable_file(
         pd.DataFrame: derived variable file for the specific cohort
     """
     df = pd.read_csv(syn.get(derived_var_synid).path, low_memory=True)
-    df = df.query(f"cohort == '{cohort}'")
+    df = df.query(f"cohort_internal == '{cohort}'")
     return df
 
 
@@ -606,6 +606,16 @@ def check_oncotree_codes(
             f"There are invalid values in ONCOTREE_CODE column in the clinical df: {invalid_codes}"
         )
 
+def check_seq_date_replacement(input_data: pd.DataFrame) -> None:
+    """Check that the replacement data's CPT_SEQ_DATE is not all missing after
+        doing the replacement.
+        
+    Args:
+        input_data (pd.DataFrame): input data after replacement
+    """
+    if input_data["CPT_SEQ_DATE"].isna().all():
+        logging.warning("All CPT_SEQ_DATE values in the data are missing after replacement.")
+
 
 def replace_cpt_seq_date(
     input_data: pd.DataFrame,
@@ -672,6 +682,7 @@ def replace_cpt_seq_date(
         on=merge_cols,
         how="left",
     )
+    check_seq_date_replacement(input_data)
     return input_data
 
 

--- a/geniesp/bpc_redcap_export_mapping.py
+++ b/geniesp/bpc_redcap_export_mapping.py
@@ -606,15 +606,21 @@ def check_oncotree_codes(
             f"There are invalid values in ONCOTREE_CODE column in the clinical df: {invalid_codes}"
         )
 
+
 def check_seq_date_replacement(input_data: pd.DataFrame) -> None:
-    """Check that the replacement data's CPT_SEQ_DATE is not all missing after
+    """Check that the replacement data's CPT_SEQ_DATE is not largely missing after
         doing the replacement.
-        
+
     Args:
         input_data (pd.DataFrame): input data after replacement
     """
-    if input_data["CPT_SEQ_DATE"].isna().all():
-        logging.warning("All CPT_SEQ_DATE values in the data are missing after replacement.")
+    missing_threshold = 0.15
+    missing_proportion = input_data["CPT_SEQ_DATE"].isna().mean()
+    if missing_proportion > missing_threshold:
+        logging.warning(
+            f"{missing_proportion:.1%} of CPT_SEQ_DATE values in the data are missing "
+            f"after replacement, which exceeds the {missing_threshold:.0%} threshold."
+        )
 
 
 def replace_cpt_seq_date(

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -22,8 +22,6 @@
                         "NSCLC",
                         "PANC",
                         "Prostate",
-                        "CRC2",
-                        "NSCLC2",
                         "MELANOMA",
                         "OVARIAN",
                         "ESOPHAGO",

--- a/tests/test_bpc_redcap_export_mapping.py
+++ b/tests/test_bpc_redcap_export_mapping.py
@@ -170,23 +170,25 @@ def test_that_check_oncotree_codes_gives_no_warning_when_all_codes_valid(caplog)
 def test_that_get_derived_variable_file_gets_file_correctly(mock_syn):
     test_df = pd.DataFrame(
         dict(
-            cohort = ["BLADDER", "BrCa", "BLADDER"],
+            cohort_internal = ["BLADDER", "CRC", "CRC"],
+            cohort = ["BLADDER", "CRC", "CRC2"],
             record_id = ["GENIE-SAGE-1", "GENIE-SAGE-2", "GENIE-SAGE-3"]
-            )
+        )
     )
-    with mock.patch.object(mock_syn, "get") as mock_syn_get, mock.patch.object(
+    with mock.patch.object(mock_syn, "get"), mock.patch.object(
         pd, "read_csv", return_value = test_df
-        ) as mock_read_csv:
+        ):
             output = bpc_export.get_derived_variable_file(
                 mock_syn, 
                 derived_var_synid = "synZZZZ", 
-                cohort = "BLADDER"
+                cohort = "CRC",
                 )
             assert_frame_equal(
                 output.reset_index(drop=True), pd.DataFrame(
                     dict(
-                        cohort = ["BLADDER", "BLADDER"],
-                        record_id = ["GENIE-SAGE-1", "GENIE-SAGE-3"]
+                        cohort_internal = ["CRC", "CRC"],
+                        cohort = ["CRC", "CRC2"],
+                        record_id = ["GENIE-SAGE-2", "GENIE-SAGE-3"]
                         )
                 ).reset_index(drop=True),
                 check_index_type=False
@@ -508,3 +510,28 @@ def test_get_timeline_imaging_sets_event_type(mock_syn):
     runner.create_fixed_timeline_files.assert_called_once()
     called_timeline_type = runner.create_fixed_timeline_files.call_args.args[1]
     assert called_timeline_type == "TIMELINE-IMAGING"
+    
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [2020, None, 2022],
+        [2020, 2021, 2022],
+    ],
+)
+def test_check_seq_date_replacement_no_warning(values, caplog):
+    df = pd.DataFrame({"CPT_SEQ_DATE": values})
+
+    with caplog.at_level(logging.WARNING):
+        bpc_export.check_seq_date_replacement(df)
+
+    assert "All CPT_SEQ_DATE values in the data are missing after replacement." not in caplog.text
+
+
+def test_check_seq_date_replacement_all_missing_warns(caplog):
+    df = pd.DataFrame({"CPT_SEQ_DATE": [None, None, None]})
+
+    with caplog.at_level(logging.WARNING):
+        bpc_export.check_seq_date_replacement(df)
+
+    assert "All CPT_SEQ_DATE values in the data are missing after replacement." in caplog.text

--- a/tests/test_bpc_redcap_export_mapping.py
+++ b/tests/test_bpc_redcap_export_mapping.py
@@ -515,8 +515,12 @@ def test_get_timeline_imaging_sets_event_type(mock_syn):
 @pytest.mark.parametrize(
     "values",
     [
-        [2020, None, 2022],
+        # no missing values
         [2020, 2021, 2022],
+        # 10% missing (<= 15% threshold)
+        [None] + [2020] * 9,
+        # exactly 15% missing (not strictly greater than threshold)
+        [None] * 3 + [2020] * 17,
     ],
 )
 def test_check_seq_date_replacement_no_warning(values, caplog):
@@ -525,13 +529,22 @@ def test_check_seq_date_replacement_no_warning(values, caplog):
     with caplog.at_level(logging.WARNING):
         bpc_export.check_seq_date_replacement(df)
 
-    assert "All CPT_SEQ_DATE values in the data are missing after replacement." not in caplog.text
+    assert "of CPT_SEQ_DATE values in the data are missing" not in caplog.text
 
 
-def test_check_seq_date_replacement_all_missing_warns(caplog):
-    df = pd.DataFrame({"CPT_SEQ_DATE": [None, None, None]})
+@pytest.mark.parametrize(
+    "values",
+    [
+        # ~33% missing (> 15% threshold)
+        [None, 2021, 2022],
+        # all missing
+        [None, None, None],
+    ],
+)
+def test_check_seq_date_replacement_above_threshold_warns(values, caplog):
+    df = pd.DataFrame({"CPT_SEQ_DATE": values})
 
     with caplog.at_level(logging.WARNING):
         bpc_export.check_seq_date_replacement(df)
 
-    assert "All CPT_SEQ_DATE values in the data are missing after replacement." in caplog.text
+    assert "of CPT_SEQ_DATE values in the data are missing" in caplog.text


### PR DESCRIPTION
# **Problem:**
When replacing `CPT_SEQ_DATE` with either the main genie's SEQ_YEAR or derived variable's `cpt_seq_date` variable, it filters the replacement data on `cohort` instead of `cohort_internal` when doing the replacement. See README changes for reasoning why this is an issue.

JIRA Ticket: https://sagebionetworks.jira.com/browse/GEN-2672

# **Solution:**
Filter on `cohort_internal` instead so that the replacement data and the data being replaced match in their filters (e.g: have both NSCLC + NSCLC2 data)

# **Testing:**
- Unit tests pass
- Staging run results in file with ~40 blanks